### PR TITLE
Correct options for space-index-pages-free-plot

### DIFF
--- a/bin/innodb_space
+++ b/bin/innodb_space
@@ -791,7 +791,7 @@ ARGV.each do |mode|
   when "space-index-pages-summary"
     space_index_pages_summary(space, @options.pages.first || 0)
   when "space-index-pages-free-plot"
-    name = File.basename(@options.file).sub(".ibd", "")
+    name = File.basename(@options.space_file).sub(".ibd", "")
     space_index_pages_free_plot(space, name, @options.pages.first || 0)
   when "space-page-type-regions"
     space_page_type_regions(space, @options.pages.first || 0)


### PR DESCRIPTION
Previously this failed with:

```
bin/innodb_space:794:in `basename': can't convert nil into String (TypeError)
        from bin/innodb_space:794:in `block in <main>'
        from bin/innodb_space:760:in `each'
        from bin/innodb_space:760:in `<main>'
```
