### PR TITLE
Only trap valid signals

### DIFF
--- a/bin/innodb_space
+++ b/bin/innodb_space
@@ -1451,8 +1451,9 @@ END_OF_USAGE
   exit exit_code
 end
 
-Signal.trap("INT")  { exit }
-Signal.trap("PIPE") { exit }
+%w[INT PIPE].each do |name|
+  Signal.trap(name) { exit } if Signal.list.include?(name)
+end
 
 @options = OpenStruct.new
 @options.trace                    = 0


### PR DESCRIPTION
Fixes https://github.com/jeremycole/innodb_ruby/issues/43

Apparently on Windows, `PIPE` is not a valid signal. Guard `Signal.trap` by checking whether a signal name is valid, which should be fine always.