### PR TITLE
Allow the data directory to be specified

### DIFF
--- a/bin/innodb_space
+++ b/bin/innodb_space
@@ -1293,9 +1293,13 @@ The following options are supported:
     --index-name, -I <name>
       Use the index name <name>.
 
-    --system-space-tables
+    --system-space-tables, -x
       Allow opening tables from the system space to support system spaces with
       tables created without innodb-file-per-table enabled.
+
+    --data-directory, -D <directory>
+      Open per-table tablespace files from <directory> rather than from the
+      directory where the system-space-file is located.
 
   --space-file, -f <file>
     Load the tablespace file <file>.
@@ -1484,6 +1488,7 @@ end
 @options.trace                    = 0
 @options.system_space_file        = nil
 @options.system_space_tables      = false
+@options.data_directory           = nil
 @options.space_file               = nil
 @options.table_name               = nil
 @options.index_name               = nil
@@ -1502,6 +1507,7 @@ getopt_options = [
   [ "--trace",                    "-t",     GetoptLong::NO_ARGUMENT ],
   [ "--system-space-file",        "-s",     GetoptLong::REQUIRED_ARGUMENT ],
   [ "--system-space-tables",      "-x",     GetoptLong::NO_ARGUMENT ],
+  [ "--data-directory",           "-D",     GetoptLong::REQUIRED_ARGUMENT ],
   [ "--space-file",               "-f",     GetoptLong::REQUIRED_ARGUMENT ],
   [ "--table-name",               "-T",     GetoptLong::REQUIRED_ARGUMENT ],
   [ "--index-name",               "-I",     GetoptLong::REQUIRED_ARGUMENT ],
@@ -1529,6 +1535,8 @@ getopt.each do |opt, arg|
     @options.system_space_file = arg.split(",")
   when "--system-space-tables"
     @options.system_space_tables = true
+  when "--data-directory"
+    @options.data_directory = arg
   when "--space-file"
     @options.space_file = arg.split(",")
   when "--table-name"
@@ -1566,12 +1574,15 @@ if @options.system_space_file && @options.space_file
   usage(1, "Only one of --system-space-file (-s) or --space-file (-f) may be specified")
 end
 
-if !@options.system_space_file && (@options.table_name || @options.index_name || @options.system_space_tables)
+system_space_options =
+  @options.table_name || @options.index_name || @options.system_space_tables || @options.data_directory
+
+if !@options.system_space_file && system_space_options
   usage(
     1,
     %{
-      The --table-name (-T), --index-name (-I), and --system-space-tables (-x) options can
-      only be used with the --system-space-file (-s) option
+      The --table-name (-T), --index-name (-I), --system-space-tables (-x), and --data-directory (-D)
+      options can only be used with the --system-space-file (-s) option
     }.squish
   )
 end
@@ -1585,7 +1596,7 @@ index = nil
 page = nil
 
 if @options.system_space_file
-  innodb_system = Innodb::System.new(@options.system_space_file)
+  innodb_system = Innodb::System.new(@options.system_space_file, data_directory: @options.data_directory)
 end
 
 if innodb_system && @options.table_name

--- a/lib/innodb/system.rb
+++ b/lib/innodb/system.rb
@@ -19,7 +19,7 @@ module Innodb
     # The space ID of the system space, always 0.
     SYSTEM_SPACE_ID = 0
 
-    def initialize(arg)
+    def initialize(arg, data_directory: nil)
       if arg.is_a?(Array) && arg.size > 1
         data_filenames = arg
       else
@@ -35,7 +35,7 @@ module Innodb
       @spaces = {}
       @orphans = []
       @config = {
-        datadir: File.dirname(data_filenames.first),
+        data_directory: data_directory || File.dirname(data_filenames.first),
       }
 
       add_space_file(data_filenames)
@@ -70,7 +70,7 @@ module Innodb
     # Add a space by table name, constructing an appropriate filename
     # from the provided table name.
     def add_table(table_name)
-      space_file = "%s/%s.ibd" % [config[:datadir], table_name]
+      space_file = "%s/%s.ibd" % [config[:data_directory], table_name]
       if File.exist?(space_file)
         add_space_file(space_file)
       else

--- a/spec/innodb/system_spec.rb
+++ b/spec/innodb/system_spec.rb
@@ -7,6 +7,25 @@ describe Innodb::System do
     @system = Innodb::System.new("spec/data/sakila/compact/ibdata1")
   end
 
+  describe "data_directory" do
+    it "cannot find tablespace files when the data directory is wrong" do
+      broken_system = Innodb::System.new("spec/data/sakila/compact/ibdata1", data_directory: "foo/bar")
+      space = broken_system.space_by_table_name("sakila/film")
+      space.should be_nil
+    end
+  end
+
+  describe "data_directory" do
+    it "can find tablespace files using a specified data directory" do
+      working_system = Innodb::System.new(
+        "spec/data/sakila/compact/ibdata1",
+        data_directory: "spec/data/sakila/compact"
+      )
+      space = working_system.space_by_table_name("sakila/film")
+      space.should be_an_instance_of(Innodb::Space)
+    end
+  end
+
   describe "#system_space" do
     it "returns an Innodb::Space" do
       @system.system_space.should be_an_instance_of Innodb::Space


### PR DESCRIPTION
Fixes https://github.com/jeremycole/innodb_ruby/issues/35

Add a new `--data-directory/-D` option to `innodb_space` to specify the data directory in case it differs from where the `ibdataN` files are found. Half of the plumbing was already done for this, so reuse that.