### PR TITLE
Add Innodb::List#empty? method and very basic test

### DIFF
--- a/lib/innodb/list.rb
+++ b/lib/innodb/list.rb
@@ -100,6 +100,11 @@ module Innodb
       @base.length
     end
 
+    # Is the list currently empty?
+    def empty?
+      length.zero?
+    end
+
     # Return the first object in the list using the list base node "first"
     # address pointer.
     def first

--- a/spec/innodb/list/history_spec.rb
+++ b/spec/innodb/list/history_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Innodb::List::History do
+  before :all do
+    @system = Innodb::System.new("spec/data/sakila/compact/ibdata1")
+    @empty_list = @system.history.each_history_list.first&.list
+  end
+
+  it "can read an empty list" do
+    @empty_list.empty?.should(be_truthy)
+  end
+end

--- a/spec/innodb/list/inode_spec.rb
+++ b/spec/innodb/list/inode_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Innodb::List::Inode do
+  before :all do
+    @system = Innodb::System.new("spec/data/sakila/compact/ibdata1")
+    @empty_list = @system.space_by_table_name("sakila/film").list(:full_inodes)
+  end
+
+  it "can read an empty list" do
+    @empty_list.empty?.should(be_truthy)
+  end
+
+  it "only iterates through INODE pages" do
+    @system.system_space.list(:full_inodes).each.map(&:type).should(eql(%i[INODE INODE]))
+  end
+end

--- a/spec/innodb/list/undo_page_spec.rb
+++ b/spec/innodb/list/undo_page_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Innodb::List::UndoPage do
+  # TODO: Add some kind of test here.
+end

--- a/spec/innodb/list/xdes_spec.rb
+++ b/spec/innodb/list/xdes_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Innodb::List::Xdes do
+  # TODO: Add some kind of test here.
+end


### PR DESCRIPTION
Fixes https://github.com/jeremycole/innodb_ruby/issues/100

The `Innodb::List#empty?` method was removed during a refactor in the past, and was used by the `undo-history-summary` mode. Add an `#empty?` method back, and a very basic test to ensure it stays. 😄 

I would like to actually test these classes but will need to generate test data containing actual history.